### PR TITLE
Add Dockerfile and modify webpack_dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:lts
+
+WORKDIR /app
+
+COPY . /app
+RUN npm i
+CMD ["npm", "start"]

--- a/webpack_dev.config.js
+++ b/webpack_dev.config.js
@@ -32,10 +32,6 @@ module.exports = {
   ],
   resolve: {
     alias: {
-      "@terminusdb/terminusdb-client": path.resolve('../terminusdb-client/index.js'),
-      "@rjsf/core": path.resolve('../react-jsonschema-form/packages/core/src/index.js'),
-      "@terminusdb/terminusdb-documents-ui": path.resolve('../terminusdb-documents-ui/src/index.js'),
-      "@terminusdb-live/terminusdb-react-table": path.resolve('../terminusdb-react-table/src/index.js'),
       react: path.resolve('./node_modules/react')
     },
     fallback: { "https": false },


### PR DESCRIPTION
If we want to develop locally with modules we should use npm link instead. I added a Dockerfile for easier development without NodeJS installed.