### PR TITLE
Fix link to CAMS schema in Step 1, point 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ TerminusX is used as our database back-end to store the critical assets.
 
 - Create a new Data Product by the ID ```CAMSDemo```
 
-- Add the CAMS schema which you will find https://github.com/CriticalAssetManagement/CAMS-Dashboard/schema.json
+- Add the the CAMS schema from https://github.com/CriticalAssetManagement/CAMS-Dashboard/blob/main/schema.JSON
 
 ### Step 2 - Clone CAMS Dashboard repo ```CAMS-Dashboard```
 


### PR DESCRIPTION
The link to the schema in the current README throws a "error: not found" when I click it. I updated the link to https://github.com/CriticalAssetManagement/CAMS-Dashboard/blob/main/schema.JSON